### PR TITLE
Check if conditions against a true boolean.  Only OUTPUT if needed

### DIFF
--- a/chart/templates/fluent-bit/fluent-bit-config-sec.yaml
+++ b/chart/templates/fluent-bit/fluent-bit-config-sec.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.fluentbit.enabled }}
+{{- if eq .Values.fluentbit.enabled true }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -57,7 +57,7 @@ stringData:
     {{- end }}
 
     # kafka output plugin configuration in case kafka is enabled in the helm chart
-    {{- if .Values.kafka.enabled }}
+    {{- if eq .Values.kafka.enabled true }}
     @INCLUDE _output-kafka.conf
     {{- else }}
     # the default opensearch output plugin configuration in case kafka is not enabled in the helm chart
@@ -121,6 +121,7 @@ stringData:
         call    dedot
 
   _output-opensearch-journals.conf: |-
+  {{ if has "systemd" .Values.opensearch_dashboards.indexPatterns }}
     [OUTPUT]
         Name                opensearch
         Match               systemd.*
@@ -149,8 +150,10 @@ stringData:
         {{- end }}
         tls.crt_file        /fluent-bit/ssl/admin.pem
         tls.key_file        /fluent-bit/ssl/admin-key.pem
+  {{ end }}
 
   _output-opensearch-containers.conf: |-
+  {{ if has "containers" .Values.opensearch_dashboards.indexPatterns }}
     [OUTPUT]
         Name                opensearch
         Match               kube.*
@@ -182,6 +185,7 @@ stringData:
         tls.crt_file        /fluent-bit/ssl/admin.pem
         tls.key_file        /fluent-bit/ssl/admin-key.pem
         Buffer_Size         1024kb
+  {{ end }}
 
   _output-kafka.conf: |-
     [OUTPUT]


### PR DESCRIPTION
2 issues with this file:

### First issue:
```
    {{- if .Values.kafka.enabled }}
```
Only tests if the variable exists, not whether it is true or false.
This was showing up when I ran:
```
helm upgrade ofd -n os-logging --create-namespace -f ./single-node-setup.yaml ./../chart --install --wait-for-jobs --timeout=30m --debug --dry-run
```
You will see the `@INCLUDE _output-kafka.conf`, even though I had defined:
```
kafka:
  enabled: false
```
Updating the if to validate the variable is set to `true` resolves this.
```
    {{- if eq .Values.kafka.enabled true }}
```

### 2nd issue
The default indexPatterns is set to:
```
opensearch_dashboards:
  indexPatterns:
    - containers
    - systemd
    - nginx

```
In my case, the containers where chewing up all available space on my system.
I had already created a custom setup so that my logs were indexed under a separate pattern.
Therefore, I was not interested in the `containers` at all.
When removing `- containers`, unfortunately, the OUTPUT is still created and logged.

This change will prevent the creation of the `[OUTPUT]` if the deployment has not requested that index.

It was put into the file using this syntax:
```
  _output-opensearch-containers.conf: |-
  {{ if has "containers" .Values.opensearch_dashboards.indexPatterns }}
    [OUTPUT]
        Name                opensearch
        Match               kube.*
        Alias               containers
        Host                ${FLUENT_opensearch_HOST}
        Port                ${FLUENT_opensearch_PORT}
        HTTP_User           ${FLUENT_opensearch_USER}
        HTTP_Passwd         ${FLUENT_opensearch_PASSWORD}
        Logstash_Format     On
        {{- if .Values.fluentbit.indexPrefix }}
        Logstash_Prefix     {{ printf "%s-containers" .Values.fluentbit.indexPrefix }}
        {{- else }}
        Logstash_Prefix     containers
        {{- end }}
...
  {{ end }}
```
I had originally set it up as:
```
  {{ if has "containers" .Values.opensearch_dashboards.indexPatterns }}
  _output-opensearch-containers.conf: |-
    [OUTPUT]
        Name                opensearch
        Match               kube.*
        Alias               containers
        Host                ${FLUENT_opensearch_HOST}
        Port                ${FLUENT_opensearch_PORT}
        HTTP_User           ${FLUENT_opensearch_USER}
        HTTP_Passwd         ${FLUENT_opensearch_PASSWORD}
        Logstash_Format     On
        {{- if .Values.fluentbit.indexPrefix }}
        Logstash_Prefix     {{ printf "%s-containers" .Values.fluentbit.indexPrefix }}
        {{- else }}
        Logstash_Prefix     containers
        {{- end }}
...
  {{ end }}
```
But later on in this file we were issuing:
```
    @INCLUDE _output-opensearch-*.conf
```
And if we had so happened to turn off BOTH the `systemd` and `containers` then this line would fail as there would be no files which would meet the wildcard.
```
opensearch_dashboards:
  indexPatterns:
    - nginx
```

Leaving it as I have has worked for me.